### PR TITLE
Fix for SemVal Printing in Colab Notebooks in Dark Mode

### DIFF
--- a/phosphorus/__init__.py
+++ b/phosphorus/__init__.py
@@ -104,7 +104,7 @@ class SemVal():
   def _repr_html_(self):
     return f"""{self}
         <span style='float:right; font-family:monospace; margin-right:75px;
-              font-weight:bold; background-color:#e5e5ff'>
+              font-weight:bold; background-color:#e5e5ff; color:#000'>
           {self.type}</span>"""
 
   def __repr__(self): return str(self.value)


### PR DESCRIPTION
The current code for printing SemVal's (the `_repr_html_` function) doesn't quite work in Google Colab notebooks that are in dark mode (or likely other dark mode Jupyter themes).

This is because dark mode themes normally print the text in white, and the light purple used for the background on the type in the HTML representation of a SemVal does not contrast well enough with white for it to be readable. This PR just changes it to add `color: #000` to the style specification of the span containing the type, to enforce that the text should be rendered in black text (which is readable against the light purple).

This change does not affect the behavior of the representation in Jupyter nor Google Colab's default theme, as these already render the output text in black font.

Some screenshots of Google Colab dark mode are included to illustrate.

Without this change:
<img width="1292" alt="Screenshot 2025-02-14 at 11 20 25 PM" src="https://github.com/user-attachments/assets/0de30928-6d0f-465b-acfe-960e7546697e" />

With this change:
<img width="1286" alt="Screenshot 2025-02-14 at 11 20 52 PM" src="https://github.com/user-attachments/assets/c40081fb-4f4f-4415-a8d1-27812450e126" />