### PR TITLE
Fix for SemVal Printing in Colab Notebooks in Dark Mode

### DIFF
--- a/phosphorus/semval.py
+++ b/phosphorus/semval.py
@@ -166,7 +166,7 @@ class PV():
 
       return f"""
       <div style="display: flex; align-items: flex-start;">
-          <div style="flex-grow: 1;">{highlighted}</div>
+          <div style="flex-grow: 1; color: #000;">{highlighted}</div>
           <div style="
               font-family: monospace;
               font-weight: bold;


### PR DESCRIPTION
This is a fix for essentially the same issue as in #1.

When in dark mode, Google Colab sets the default text color in the HTML representation of Python objects output in a cell to white. Since PVs are printed with a light background, in dark mode, this results in Colab printing white text against the light background, which is difficult to read.

This change just adds `color: #000` as an inline style to the `<div>` in which the body of the PV is printed, in order to force the text to be rendered as black always.

Note that this change does not affect how a PV is represented in the default light theme of Jupyter or Google Colab. It also does not affect the syntax highlighting within the body, as the inline styles on individual `<span>`s within the overall `<div>` override the global style set in this change.

Some screenshots of Google Colab (in dark mode) are included below to illustrate.

Without this change:
<img width="1099" alt="Screenshot 2025-04-06 at 12 02 34 AM" src="https://github.com/user-attachments/assets/714b35af-1b8a-495a-88bf-d894f39d56ef" />

With this change:
<img width="1101" alt="Screenshot 2025-04-06 at 12 02 42 AM" src="https://github.com/user-attachments/assets/e6068cd8-5b67-433b-a479-237872939919" />
